### PR TITLE
Explicitly ask for vulkan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 anyhow = "1.0.75"
 ash = "0.37.3"
 bevy = { git = "https://github.com/awtterpip/bevy", default-features = false, features = ["bevy_render"] }
-openxr = {version = "0.17.1" }
+openxr = { version = "0.17.1" }
 wgpu = "0.16.0"
-wgpu-core = "0.16.0"
+wgpu-core = { version = "0.16.0", features = ["vulkan"] }
 wgpu-hal = "0.16.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Without this, it errors on macos. My guess is because by default, vulkan backend is not enabled on mac.

```
   Compiling bevy v0.12.0-dev (https://github.com/awtterpip/bevy#96876698)
   Compiling color-eyre v0.6.2
   Compiling bevy_openxr v0.1.0 (https://github.com/awtterpip/bevy_openxr?rev=9361991a5f
error[E0432]: unresolved import `wgpu_hal::api::Vulkan`
  --> /Users/ryan/.cargo/git/checkouts/bevy_openxr-1dedcf84dfa11c13/9361991/src/graphics
   |
36 |     use wgpu_hal::{api::Vulkan as V, Api};
   |                    ^^^^^^^^^^^^^^^^ no `Vulkan` in `api`
   |
   = help: consider importing one of these items instead:
           crate::Swapchain::Vulkan
           crate::xr::Vulkan
           openxr::Vulkan
           wgpu::Backend::Vulkan
note: found an item that was configured out
  --> /Users/ryan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-hal-0.16.2/src/lib.rs:84:35
   |
84 |     pub use super::vulkan::Api as Vulkan;
   |                                   ^^^^^^

error[E0412]: cannot find type `Vulkan` in module `wgpu_hal::api`
   --> /Users/ryan/.cargo/git/checkouts/bevy_openxr-1dedcf84dfa11c13/9361991/src/graphics/vulkan.rs:236:60
    |
236 | ...al::<wgpu_hal::api::Vulkan>(wgpu_vk_instance) };
    |                        ^^^^^^ not found in `wgpu_hal::api`
    |
note: found an item that was configured out
   --> /Users/ryan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-hal-0.16.2/src/lib.rs:84:35
    |
84  |     pub use super::vulkan::Api as Vulkan;
    |                                   ^^^^^^
help: consider importing one of these items
    |
1   + use crate::xr::Vulkan;
    |
1   + use openxr::Vulkan;
    |
help: if you import `Vulkan`, refer to it directly
    |
236 -         unsafe { wgpu::Instance::from_hal::<wgpu_hal::api::Vulkan>(wgpu_vk_instance) };
236 +         unsafe { wgpu::Instance::from_hal::<Vulkan>(wgpu_vk_instance) };
    |

Some errors have detailed explanations: E0412, E0432.
For more information about an error, try `rustc --explain E0412`.
error: could not compile `bevy_openxr` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```