### PR TITLE
xr_wait_frame lock match instead of unwrap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,13 @@ pub fn xr_begin_frame(
     }
     {
         let _span = info_span!("xr_wait_frame").entered();
-        *frame_state.lock().unwrap() = frame_waiter.lock().unwrap().wait().unwrap();
+        *frame_state.lock().unwrap() = match frame_waiter.lock().unwrap().wait() {
+            Ok(a) => a,
+            Err(e) => {
+                warn!("error: {}", e);
+                return;
+            }
+        };
     }
     {
         let _span = info_span!("xr_begin_frame").entered();


### PR DESCRIPTION
Should fix #19

I somehow didn't copy this part from [android](https://github.com/awtterpip/bevy_openxr/tree/android) branch here, to my android PR #18.
So yes, on quest 2 I see same error sometimes without this patch.

 