### PR TITLE
Android example xbuild

### DIFF
--- a/examples/android/README.md
+++ b/examples/android/README.md
@@ -5,10 +5,25 @@ Get libopenxr_loader.so from the Oculus OpenXR Mobile SDK and add it to `example
 https://developer.oculus.com/downloads/package/oculus-openxr-mobile-sdk/
 `examples/android/runtime_libs/arm64-v8a/libopenxr_loader.so`
 
+## Run
 Running on Meta Quest can be done with https://github.com/rust-mobile/cargo-apk. 
 ```sh 
 cargo apk run --release
 ```
+But cargo-apk is deprecated in favour of xbuild https://github.com/rust-mobile/xbuild.
+```sh 
+# Install latest version of xbuild
+cargo install --git https://github.com/rust-mobile/xbuild
+```
+```sh 
+# List devices and copy device string "adb:***"
+x devices
+
+# Run on this device
+x run --release --device adb:***
+```
+There is [manifest.yaml](./manifest.yaml) example required by xbuild.
+Interface for this manifest can be found as AndroidConfig struct in https://github.com/rust-mobile/xbuild/blob/master/xbuild/src/config.rs
 
 ## Notes
 

--- a/examples/android/manifest.yaml
+++ b/examples/android/manifest.yaml
@@ -1,0 +1,25 @@
+android:
+  runtime_libs:
+    - "runtime_libs"
+  manifest:
+    package: "org.bevyengine.example_openxr_android"
+    application:
+      label: "Bevy Openxr Android"
+      theme: "@android:style/Theme.DeviceDefault.NoActionBar.Fullscreen"
+      meta_data:
+        - name: "com.samsung.android.vr.application.mode"
+          value: "vr_only"
+        - name: "com.oculus.supportedDevices"
+          value: "quest|quest2|quest3"
+      activities:
+        - config_changes: "density|keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|uiMode"
+          launch_mode: "singleTask"
+          orientation: "landscape"
+          intent_filters:
+            - actions:
+                - "android.intent.action.MAIN"
+              categories:
+                - "com.oculus.intent.category.VR"
+                - "android.intent.category.LAUNCHER"
+    sdk:
+      target_sdk_version: 32


### PR DESCRIPTION
cargo-apk is deprecated in favour of xbuild https://github.com/rust-mobile/xbuild
https://github.com/rust-mobile/cargo-apk/commit/558adff4f77740bc3a9353e2a8350064fa2942bd

I tried to make it work with xbuild. And it required to write manifest.yaml.
So my proposal it to just add this manifest.yaml to the example, and it starts working with xbuild.