### PR TITLE
Implement get_frustum_corners

### DIFF
--- a/src/xr_input/xr_camera.rs
+++ b/src/xr_input/xr_camera.rs
@@ -1,6 +1,7 @@
 use crate::xr_input::{QuatConv, Vec3Conv};
 use crate::{LEFT_XR_TEXTURE_HANDLE, RIGHT_XR_TEXTURE_HANDLE};
 use bevy::core_pipeline::tonemapping::{DebandDither, Tonemapping};
+use bevy::math::Vec3A;
 use bevy::prelude::*;
 use bevy::render::camera::{CameraProjection, CameraRenderGraph, RenderTarget};
 use bevy::render::primitives::Frustum;
@@ -215,6 +216,26 @@ impl CameraProjection for XRProjection {
 
     fn far(&self) -> f32 {
         self.far
+    }
+
+    fn get_frustum_corners(&self, z_near: f32, z_far: f32) -> [Vec3A; 8] {
+        let tan_angle_left = self.fov.angle_left.tan();
+        let tan_angle_right = self.fov.angle_right.tan();
+
+        let tan_angle_bottom = self.fov.angle_down.tan();
+        let tan_angle_top = self.fov.angle_up.tan();
+
+        // NOTE: These vertices are in the specific order required by [`calculate_cascade`].
+        [
+            Vec3A::new(tan_angle_right, tan_angle_bottom, 1.0) * z_near, // bottom right
+            Vec3A::new(tan_angle_right, tan_angle_top, 1.0) * z_near,    // top right
+            Vec3A::new(tan_angle_left, tan_angle_top, 1.0) * z_near,     // top left
+            Vec3A::new(tan_angle_left, tan_angle_bottom, 1.0) * z_near,  // bottom left
+            Vec3A::new(tan_angle_right, tan_angle_bottom, 1.0) * z_far,  // bottom right
+            Vec3A::new(tan_angle_right, tan_angle_top, 1.0) * z_far,     // top right
+            Vec3A::new(tan_angle_left, tan_angle_top, 1.0) * z_far,      // top left
+            Vec3A::new(tan_angle_left, tan_angle_bottom, 1.0) * z_far,   // bottom left
+        ]
     }
 }
 


### PR DESCRIPTION
This PR ports [get_frustum_corners](https://github.com/bevyengine/bevy/pull/9226/files#diff-17834fc6389be55867ad34d896b05322c64245f8a46da89ba932e99d44ba305dR165-R181) to `XRProjection`, as it's a new required method of `CameraProjection`. I do not do `.abs()` like the original code, because the _[original](https://github.com/bevyengine/bevy/pull/7064/files#diff-c60eda8fbc401d2abd66241ba0ece700ad17d8ae3acef6a6196652ca70b4fa4cR400-R408)_ original asserts that the near and far are negative and then calls `.abs()`, while the [new code](https://github.com/bevyengine/bevy/pull/9226/files#diff-c60eda8fbc401d2abd66241ba0ece700ad17d8ae3acef6a6196652ca70b4fa4cR450-R457) negates the Z before passing it in, hopefully meaning that it's always positive. (I think this means the `.abs()` in the upstream code is redundant now too.)