### PR TITLE
Make `openxr` features platform agnostic to fix `CMake error: ...` common issue.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Cache"
         uses: Swatinem/rust-cache@v2
       - name: "External dependencies"
-        run: sudo apt-get install -y libasound2-dev portaudio19-dev build-essential libpulse-dev libdbus-1-dev libudev-dev libopenxr-loader1
+        run: sudo apt-get install -y libasound2-dev portaudio19-dev build-essential libpulse-dev libdbus-1-dev libudev-dev libopenxr-loader1 libopenxr-dev
       - name: "Checks"
         run: |
           cargo update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Cache"
         uses: Swatinem/rust-cache@v2
       - name: "External dependencies"
-        run: sudo apt-get install -y libasound2-dev portaudio19-dev build-essential libpulse-dev libdbus-1-dev libudev-dev
+        run: sudo apt-get install -y libasound2-dev portaudio19-dev build-essential libpulse-dev libdbus-1-dev libudev-dev libopenxr-loader1
       - name: "Checks"
         run: |
           cargo update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ wgpu = "0.17.1"
 wgpu-core = { version = "0.17.1", features = ["vulkan"] }
 wgpu-hal = "0.17.1"
 
-[target.'cfg( target_os = "linux" )'.dependencies]
+[target.'cfg( target_family = "unix" )'.dependencies]
 openxr = "0.17.1"
 
-[target.'cfg(not(target_os = "linux"))'.dependencies]
+[target.'cfg(not(target_family = "unix"))'.dependencies]
 openxr = { version = "0.17.1", features = ["static"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["openxr/mint"]
+default = ["openxr/mint", "linked"]
+linked = ["openxr/linked"]
 
 [dependencies]
 anyhow = "1.0.75"
@@ -16,7 +17,7 @@ wgpu-core = { version = "0.17.1", features = ["vulkan"] }
 wgpu-hal = "0.17.1"
 
 [target.'cfg( target_os = "linux" )'.dependencies]
-openxr = { version = "0.17.1", features = ["linked"] }
+openxr = "0.17.1"
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 openxr = { version = "0.17.1", features = ["static"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,18 +4,22 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["linked"]
-linked = ["openxr/linked", "openxr/static"]
+default = ["openxr/mint"]
 
 [dependencies]
 anyhow = "1.0.75"
 ash = "0.37.3"
 bevy = "0.12"
-openxr = { version = "0.17.1", features = ["mint"] }
 mint = "0.5.9"
 wgpu = "0.17.1"
 wgpu-core = { version = "0.17.1", features = ["vulkan"] }
 wgpu-hal = "0.17.1"
+
+[target.'cfg( target_os = "linux" )'.dependencies]
+openxr = { version = "0.17.1", features = ["linked"] }
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+openxr = { version = "0.17.1", features = ["linked", "static"] }
 
 [dev-dependencies]
 bevy = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ wgpu-hal = "0.17.1"
 openxr = { version = "0.17.1", features = ["linked"] }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
-openxr = { version = "0.17.1", features = ["linked", "static"] }
+openxr = { version = "0.17.1", features = ["static"] }
 
 [dev-dependencies]
 bevy = "0.12"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ To see it in action run the example in `examples` with `cargo run --example xr`
 
 ## Troubleshooting
 
-- I'm getting a `CMake error: ...` on Linux.
-    - Make sure you have the `openxr` package installed on your system.
-    - Append `--no-default-features` to your build command (example: `cargo run --example xr --no-default-features`)
+- Make sure, if you're on Linux, that you have the `openxr` package installed on your system.
 - I'm getting poor performance.
     - Like other bevy projects, make sure you're building in release (example: `cargo run --example xr --release`)

--- a/README.md
+++ b/README.md
@@ -4,3 +4,11 @@ An in-progress crate for adding openxr support to Bevy without forking.
 ![image](https://github.com/awtterpip/bevy_openxr/assets/50841145/aa01fde4-7915-49b9-b486-ff61ce6d57a9)
 
 To see it in action run the example in `examples` with `cargo run --example xr`
+
+## Troubleshooting
+
+- I'm getting a `CMake error: ...` on Linux.
+    - Make sure you have the `openxr` package installed on your system.
+    - Append `--no-default-features` to your build command (example: `cargo run --example xr --no-default-features`)
+- I'm getting poor performance.
+    - Like other bevy projects, make sure you're building in release (example: `cargo run --example xr --release`)

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -36,9 +36,9 @@ pub fn initialize_xr_graphics(
 }
 
 pub fn xr_entry() -> xr::Entry {
-    #[cfg(feature = "linked")]
+    #[cfg(target_os = "linux")]
     let entry = xr::Entry::linked();
-    #[cfg(not(feature = "linked"))]
+    #[cfg(not(target_os = "linux"))]
     let entry = unsafe { xr::Entry::load().unwrap() };
     entry
 }

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -36,9 +36,9 @@ pub fn initialize_xr_graphics(
 }
 
 pub fn xr_entry() -> xr::Entry {
-    #[cfg(target_os = "linux")]
+    #[cfg(feature = "linked")]
     let entry = xr::Entry::linked();
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(feature = "linked"))]
     let entry = unsafe { xr::Entry::load().unwrap() };
     entry
 }


### PR DESCRIPTION
This attempts to resolve the common issue with the `CMake error: ...` that people keep running into by making use of platform-specific dependency changes in the `cargo.toml`.