### PR TITLE
Ignore end_frame error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,15 +330,18 @@ pub fn end_frame(
     }
     {
         let _span = info_span!("xr_end_frame").entered();
-        swapchain
+        let result = swapchain
             .end(
                 xr_frame_state.lock().unwrap().predicted_display_time,
                 &*views.lock().unwrap(),
                 &input.stage,
                 **resolution,
                 **environment_blend_mode,
-            )
-            .unwrap();
+            );
+        match result {
+            Ok(_) => {},
+            Err(_) => {},
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,7 +340,7 @@ pub fn end_frame(
             );
         match result {
             Ok(_) => {},
-            Err(_) => {},
+            Err(e) => warn!("error: {}", e),
         }
     }
 }


### PR DESCRIPTION
Fixes #26 

It would be preferable if we only ignored ERROR_SESSION_NOT_RUNNING and continued panicking on other errors, however the constant is in a private module in the openxr-sys crate and my Rust knowledge is lacking on how to extract it.