### PR TITLE
add repository to package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "bevy_oxr"
 version = "0.1.0"
 edition = "2021"
 description = "Community crate for OpenXR in Bevy"
+repository = "https://github.com/awtterpip/bevy_openxr"
 license = "MIT/Apache-2.0"
 
 [features]


### PR DESCRIPTION
This way a link to the repo shows up on crates.io