### PR TITLE
Update Cargo.toml to allow building crate for android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ wgpu-hal = "0.17.1"
 openxr = "0.17.1"
 
 [target.'cfg(not(target_family = "unix"))'.dependencies]
-openxr = { version = "0.17.1", features = ["static"] }
+openxr = { version = "0.17.1", features = ["static","linked"] }
 
 [dev-dependencies]
 bevy = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/awtterpip/bevy_openxr"
 license = "MIT/Apache-2.0"
 
 [features]
-default = ["openxr/mint", "linked"]
+default = ["openxr/mint"]
 linked = ["openxr/linked"]
 
 [workspace]


### PR DESCRIPTION
maybe i should add openxr/linked to the not unix case